### PR TITLE
Updated indexes in models

### DIFF
--- a/backend/dal/models/climate_data.py
+++ b/backend/dal/models/climate_data.py
@@ -17,8 +17,9 @@ CREATE TABLE IF NOT EXISTS CLIMATEDATA (
 """
 class ClimateData(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
-    location_id: int = Field(foreign_key="locations.id", nullable=False)
-    metric_id: int = Field(foreign_key="metrics.id", nullable=False)
-    date: str = Field(sa_column=DATE)
+    location_id: int = Field(foreign_key="locations.id", nullable=False, index = True)
+    metric_id: int = Field(foreign_key="metrics.id", nullable=False, index = True)
+    date: str = Field(index = True)
     value: float
     quality: str
+    quality_weight: float = Field(index = True)

--- a/backend/dal/models/metrics.py
+++ b/backend/dal/models/metrics.py
@@ -16,6 +16,6 @@ CREATE TABLE IF NOT EXISTS METRICS (
 class Metrics(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     name: str
-    display_name: str
+    display_name: str = Field(index = True)
     unit: str
     description: str

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -12,6 +12,13 @@ SEED_FILE_NAME = "../data/sample_data.json"
 with open(SEED_FILE_NAME, 'r') as file:
     data = json.load(file)
 
+QUALITY_WEIGHTS = {
+    'excellent': 1.0,
+    'good': 0.8,
+    'questionable': 0.5,
+    'poor': 0.3
+}
+
 locations_seed = data["locations"]
 metrics_seed = data["metrics"]
 climate_data_seeds = data["climate_data"]
@@ -50,6 +57,7 @@ def create_climate_data_from_seed():
             metric_id=climate_data_seed["metric_id"],
             date=climate_data_seed["date"],
             value=climate_data_seed["value"],
-            quality=climate_data_seed["quality"]
+            quality=climate_data_seed["quality"],
+            quality_weight = QUALITY_WEIGHTS[climate_data_seed["quality"]]
         )
         create_climate_data(climate_data)


### PR DESCRIPTION
Indexes help with upping faster read and join time, but slow down writing new data into tables. In order to avoid having any unnecessary speed downgrade, I adjusted the columns that needed an index according to the api specification and removed any unnecessary ones

Looking at the API specification, some fields/columns had values that needed indexes and some that did not:
- location_id
- Date
- metric_name
- quality_weights

<img width="1048" alt="image" src="https://github.com/user-attachments/assets/cd872aca-e75e-48f2-82ff-3fabdb381253" />

Added quality weights after reevaluating filtering through quality names

Most databases like mysql create an index on the foreign key, however, psql doesn't support that and indexes need to be declared manually. This is the reason why they are indexes on the foreign keys on metric_id and location_id in climatedata.

<img width="636" alt="Screenshot 2025-04-14 at 11 49 20 AM" src="https://github.com/user-attachments/assets/86123b62-b93e-46c6-ba14-fc0465052c80" />
<img width="463" alt="Screenshot 2025-04-14 at 11 49 57 AM" src="https://github.com/user-attachments/assets/339f4dbc-a3f5-418e-8095-f7c27539239e" />
<img width="462" alt="Screenshot 2025-04-14 at 11 50 18 AM" src="https://github.com/user-attachments/assets/13d70b2b-8983-458d-84cc-0e46ec493b45" />

